### PR TITLE
Debounce timezone lookup and cache geolocation

### DIFF
--- a/codexhorary/frontend/src/App.jsx
+++ b/codexhorary/frontend/src/App.jsx
@@ -1279,17 +1279,21 @@ const EnhancedChartCasting = ({ setCurrentChart, setCurrentView, darkMode, apiSt
 
   // Auto-update timezone when location changes (only if not using manual timezone)
   useEffect(() => {
+    let timeoutId;
     if (location.trim() && !useManualTimezone) {
-      getTimezoneFromLocation(location).then(detectedTimezone => {
-        if (detectedTimezone !== timezone) {
-          setTimezone(detectedTimezone);
-        }
-      }).catch(error => {
-        console.warn('Timezone detection failed:', error);
-        // Keep current timezone on error
-      });
+      timeoutId = setTimeout(() => {
+        getTimezoneFromLocation(location).then(detectedTimezone => {
+          if (detectedTimezone !== timezone) {
+            setTimezone(detectedTimezone);
+          }
+        }).catch(error => {
+          console.warn('Timezone detection failed:', error);
+          // Keep current timezone on error
+        });
+      }, 300);
     }
-  }, [location, useManualTimezone, timezone]);
+    return () => clearTimeout(timeoutId);
+  }, [location, useManualTimezone]);
 
   const handleLocationChange = (value) => {
     setLocation(value);


### PR DESCRIPTION
## Summary
- Debounce timezone detection in the frontend to limit rapid requests and run only when location or manual toggle changes
- Cache backend geocoding and timezone lookups with `lru_cache` and reuse them in the `/api/get-timezone` route

## Testing
- `pip install -r codexhorary/backend/requirements.txt`
- `pytest codexhorary/backend/test_benefic_presence.py`
- `npm install --no-fund --no-audit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d80b29748324b9da4c8759f5d4bf