### PR TITLE
Broaden Void Moon cleanup regex and expand tests

### DIFF
--- a/codexhorary/frontend/src/App.jsx
+++ b/codexhorary/frontend/src/App.jsx
@@ -7,7 +7,7 @@ const cleanMoonText = (text) => {
   
   return text
     // Remove duplicate "Moon" references
-    .replace(/Void ☽ Moon: ☽ Moon/g, 'Void Moon:')
+    .replace(/Void(?: ☽)? Moon:\s*(?:☽\s*)?Moon/gi, 'Void Moon:')
     .replace(/☽ Moon/g, 'Moon')
     .replace(/Moon Moon/g, 'Moon')
     // Remove trailing parentheticals like "(moon)"

--- a/codexhorary/frontend/src/utils/buildChartPayload.js
+++ b/codexhorary/frontend/src/utils/buildChartPayload.js
@@ -4,7 +4,7 @@ const cleanMoonText = (text) => {
   
   return text
     // Remove duplicate "Moon" references
-    .replace(/Void ☽ Moon: ☽ Moon/g, 'Void Moon:')
+    .replace(/Void(?: ☽)? Moon:\s*(?:☽\s*)?Moon/gi, 'Void Moon:')
     .replace(/☽ Moon/g, 'Moon')
     .replace(/Moon Moon/g, 'Moon')
     // Remove trailing parentheticals like "(moon)"

--- a/codexhorary/frontend/tests/ui-improvements.test.js
+++ b/codexhorary/frontend/tests/ui-improvements.test.js
@@ -71,7 +71,7 @@ export const testTextCleanup = () => {
     if (!text || typeof text !== 'string') return text;
     
     return text
-      .replace(/Void ☽ Moon: ☽ Moon/g, 'Void Moon:')
+      .replace(/Void(?: ☽)? Moon:\s*(?:☽\s*)?Moon/gi, 'Void Moon:')
       .replace(/☽ Moon/g, 'Moon')
       .replace(/Moon Moon/g, 'Moon')
       .replace(/\s*\([^)]*moon[^)]*\)\s*$/gi, '')
@@ -83,6 +83,10 @@ export const testTextCleanup = () => {
   const tests = [
     {
       input: 'Void ☽ Moon: ☽ Moon makes no more aspects before leaving Capricorn (moon)',
+      expected: 'Void Moon: makes no more aspects before leaving Capricorn'
+    },
+    {
+      input: 'Void Moon: Moon makes no more aspects before leaving Capricorn',
       expected: 'Void Moon: makes no more aspects before leaving Capricorn'
     },
     {


### PR DESCRIPTION
## Summary
- Improve `cleanMoonText` regex in App and payload builder to handle glyphs or plain text
- Extend unit tests for text cleanup to cover raw "Void Moon" input

## Testing
- `npm test`
- `node -e "import('./tests/ui-improvements.test.js').then(m=>m.runAllTests());"`


------
https://chatgpt.com/codex/tasks/task_e_68a1e0d386c4832496ebfbe33152c4ac